### PR TITLE
Fix endif in mini.c

### DIFF
--- a/examples/mini/mini.c
+++ b/examples/mini/mini.c
@@ -499,8 +499,7 @@ int __init init_mini_module(void)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 69)
     setup_timer(&timer, cyclic_task, 0);
 #else
-     timer_setup(&timer, cyclic_task, 0);
-#endif
+    timer_setup(&timer, cyclic_task, 0);
     timer.function = cyclic_task;
 #endif
     timer.expires = jiffies + 10;


### PR DESCRIPTION
There is a double endif here and it can't compile. I'm not deep into the ethercat topic so it would be great to check.

Thanks a lot!